### PR TITLE
Add closing quote to version number in podspec

### DIFF
--- a/SwiftLoader.podspec
+++ b/SwiftLoader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwiftLoader"
-  s.version          = "0.2.3
+  s.version          = "0.2.3"
   s.summary          = "A simple and beautiful activity indicator"
   s.description      = <<-DESC
   SwiftLoader is a simple and beautiful activity indicator written in Swift.


### PR DESCRIPTION
Can't use version 0.2.3 until this is fixed. I think you also need to create a `0.2.3` tag for it to show up on cocoapods.
